### PR TITLE
Add C/C++ debug template

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+PointerAlignment: Left
+ColumnLimit: 120

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,6 @@
 	"name": "debug_template",
 	"runArgs": [
 		"--shm-size=16g",
-		// "--gpu=all",
 		"--network=host"
 	],
 	"workspaceFolder": "/workspace",
@@ -17,7 +16,6 @@
 				"terminal.integrated.defaultProfile.linux": "tmux"
 			},
 			"extensions": [
-				// common
 				"oderwat.indent-rainbow",
 				"shardulm94.trailing-spaces",
 				"christian-kohler.path-intellisense",
@@ -25,38 +23,28 @@
 				"mosapride.zenkaku",
 				"vscode-icons-team.vscode-icons",
 				"streetsidesoftware.code-spell-checker",
-				// python
 				"ms-python.python",
 				"charliermarsh.ruff",
 				"ms-python.mypy-type-checker",
 				"ms-toolsai.jupyter",
 				"njpwerner.autodocstring",
-				// C/C+++
 				"ms-vscode.cpptools",
-				"xaver.clang-format",
+				"llvm-vs-code-extensions.vscode-clangd",
 				"jeff-hykin.better-cpp-syntax",
 				"ms-vscode.cmake-tools",
-				// git
 				"mhutchie.git-graph",
 				"donjayamanne.githistory",
 				"eamodio.gitlens",
-				// shell
 				"timonwong.shellcheck",
-				// markdown
 				"yzhang.markdown-all-in-one",
 				"yzane.markdown-pdf",
 				"shd101wyy.markdown-preview-enhanced",
 				"davidanson.vscode-markdownlint",
-				// drawio
 				"hediet.vscode-drawio",
-				// mermaid
 				"bierner.markdown-mermaid",
-				// csv
 				"mechatroner.rainbow-csv",
 				"janisdd.vscode-edit-csv",
-				// toml
 				"tamasfe.even-better-toml",
-				// others
 				"vincent-templier.vscode-netron"
 			]
 		}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,14 @@
             ],
             "console": "integratedTerminal",
             "justMyCode": true
+        },
+        {
+            "name": "C++: Current File",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${fileDirname}/build/${fileBasenameNoExtension}.out",
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,7 @@
             "justMyCode": true
         },
         {
-            "name": "C++: Current File",
+            "name": "C/C++: Current File",
             "type": "cppdbg",
             "request": "launch",
             "program": "${fileDirname}/build/${fileBasenameNoExtension}.out",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,14 @@
             "program": "${fileDirname}/build/${fileBasenameNoExtension}.out",
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "C/C++: debug cppdebug_template example",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/cppdebug_template/build/debug/src/example/example",
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-	// Python
 	"[python]": {
 		"editor.formatOnSave": true,
 		"editor.rulers": [
@@ -7,7 +6,6 @@
 		],
 		"editor.defaultFormatter": "charliermarsh.ruff",
 		"editor.codeActionsOnSave": {
-			// "source.fixAll.ruff": "explicit",
 			"source.fixAll": "explicit",
 			"source.organizeImports.ruff": "explicit"
 		}
@@ -27,6 +25,12 @@
 	],
 	"mypy-type-checker.args": [
 		"--config=${workspaceFolder}/pyproject.toml"
-	]
-	// C++
+	],
+	"[cpp]": {
+		"editor.formatOnSave": true,
+		"editor.rulers": [
+			120
+		],
+		"editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
+	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,11 @@
 		],
 		"editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
 	},
-	"cmake.sourceDirectory": "/workspace/cppdebug_template",
-	"cmake.useCMakePresets": "always"
+	"cmake.sourceDirectory": "${workspaceFolder}/cppdebug_template",
+	"cmake.useCMakePresets": "always",
+	"clangd.arguments": [
+		"--compile-commands-dir=${workspaceFolder}/cppdebug_template/build/debug"
+	],
+	"C_Cpp.intelliSenseEngine": "disabled",
+	"C_Cpp.autocomplete": "disabled"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,5 +32,7 @@
 			120
 		],
 		"editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
-	}
+	},
+	"cmake.sourceDirectory": "/workspace/cppdebug_template",
+	"cmake.useCMakePresets": "always"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "C/C++: g++ debug build current file",
+			"type": "cppbuild",
+			"command": "/usr/bin/g++",
+			"args": [
+				"${fileDirname}/${fileBasename}",
+				"-g",
+				"-O0",
+				"-o",
+				"${fileDirname}/build/${fileBasenameNoExtension}.out"
+			],
+			"problemMatcher": [
+				"$gcc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,8 @@
 			"group": {
 				"kind": "build",
 				"isDefault": true
-			}
+			},
+			"detail": "Build current single C/C++ file with g++."
 		}
 	]
 }

--- a/cppdebug_template/CMakeLists.txt
+++ b/cppdebug_template/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+project(CppDebugTemplate)
+
+add_subdirectory(src/lib/matrix_calc)
+add_subdirectory(src/example)

--- a/cppdebug_template/CMakeLists.txt
+++ b/cppdebug_template/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.29)
 project(CppDebugTemplate)
-
 add_subdirectory(src/lib/matrix_calc)
 add_subdirectory(src/example)

--- a/cppdebug_template/CMakePresets.json
+++ b/cppdebug_template/CMakePresets.json
@@ -9,6 +9,7 @@
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "/usr/bin/gcc",
                 "CMAKE_CXX_COMPILER": "/usr/bin/g++",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "Yes",
                 "CMAKE_BUILD_TYPE": "Debug"
             }
         },

--- a/cppdebug_template/CMakePresets.json
+++ b/cppdebug_template/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "debug",
+            "description": "CMake presets of debug build for cppdebug_template",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/debug",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "/usr/bin/gcc",
+                "CMAKE_CXX_COMPILER": "/usr/bin/g++",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "release",
+            "description": "CMake presets of release build for cppdebug_template",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/release",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "/usr/bin/gcc",
+                "CMAKE_CXX_COMPILER": "/usr/bin/g++",
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ]
+}

--- a/cppdebug_template/include/matrix_calc/matrix_calc.hpp
+++ b/cppdebug_template/include/matrix_calc/matrix_calc.hpp
@@ -1,0 +1,27 @@
+#ifndef MATRIX_CULC_HPP
+#define MATRIX_CULC_HPP
+
+#include <iostream>
+#include <vector>
+
+void dummy_func();
+
+template <typename T>
+void print_matrix(std::vector<std::vector<T>>& matrix) {
+  // assume row-major
+  for (int i = 0; i < matrix.size(); i++) {
+    for (int j = 0; j < matrix[0].size(); j++) {
+      if (j != 0) {
+        std::cout << " ";
+      }
+      std::cout << matrix[i][j];
+    }
+    std::cout << "\n";
+  }
+}
+
+template <typename T>
+std::vector<std::vector<T>> matrix_mul_naive(std::vector<std::vector<T>> matrix_a,
+                                             std::vector<std::vector<T>> matrix_b);
+
+#endif  // MATRIX_CULC_HPP

--- a/cppdebug_template/src/example/CMakeLists.txt
+++ b/cppdebug_template/src/example/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(example example.cpp)
+
+target_link_libraries(example matrix_calc)

--- a/cppdebug_template/src/example/example.cpp
+++ b/cppdebug_template/src/example/example.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <vector>
+
+#include "matrix_calc.hpp"
+
+using std::cout;
+using std::endl;
+using std::vector;
+
+void hello_world() { std::cout << "Hello, world!" << std::endl; }
+
+int main() {
+  vector<vector<int>> matrix_a = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+  vector<vector<int>> matrix_b = {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}};
+  vector<vector<int>> matrix_c;
+
+  hello_world();
+
+  matrix_c = matrix_mul_naive(matrix_a, matrix_b);
+  cout << "matrix a" << endl;
+  print_matrix(matrix_a);
+  cout << "matrix b" << endl;
+  print_matrix(matrix_b);
+  cout << "matrix c (matrix multiplication result)" << endl;
+  print_matrix(matrix_c);
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     openssh-client \
     pkg-config \
     gdb \
-    clang-format \
+    clangd \
     cmake \
     ninja-build
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG USERNAME="developer"
 ARG GROUPNAME="developer"
@@ -24,13 +24,20 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     pkg-config \
     gdb \
     clangd \
-    cmake \
+    lsb-release \
+    software-properties-common \
+    gpg-agent \
     ninja-build
+
+# Specific version CMake
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - \
+    && apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" \
+    && apt-get update && apt-get install -y cmake-data=3.29.6-0kitware1ubuntu22.04.1 cmake=3.29.6-0kitware1ubuntu22.04.1
 
 # Python packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
-    python3.8 \
+    python3.10 \
     python3-pip \
     python-is-python3
 


### PR DESCRIPTION
# Main Changes
- Add C/C++ debug template including
  - simple example, which can be build with CMake
  - build and debug using VScode extension, CMake Tools
    - CMake Tools configuration can be done through CMakePresets.json
  - clnangd intellisense

# Test
- Confirm example is built with CMake Tools
- Debug is available through launch.json
- Clangd intellisense works